### PR TITLE
Return the node's friendly name as well

### DIFF
--- a/ansible/dimensiondata/dimensiondata.py
+++ b/ansible/dimensiondata/dimensiondata.py
@@ -230,6 +230,7 @@ EXAMPLES = '''
 def node_to_node_obj(node):
     node_obj = {}
     node_obj['id'] = node.id
+    node_obj['name'] = node.name
     node_obj['ipv6'] = node.extra['ipv6']
     node_obj['os_type'] = node.extra['OS_type']
     node_obj['private_ipv4'] = node.private_ips


### PR DESCRIPTION
This change adds the ability to return the node's friendly name
(not its hostname) which can be useful for certain types of playbooks.
Note that this is not the same as the node's hostname which cannot
be set at this point.