### PR TITLE
Multiple fixes (Details in the description)

### DIFF
--- a/ansible/dimensiondata/dimensiondata_compute.py
+++ b/ansible/dimensiondata/dimensiondata_compute.py
@@ -5,7 +5,7 @@ from ansible.module_utils.dimensiondata import *
 HAS_LIBCLOUD = True
 try:
     from libcloud.common.dimensiondata import DimensionDataAPIException
-    from libcloud.compute.types import Provider
+    from libcloud.compute.types import Provider, InvalidCredsError
     from libcloud.compute.providers import get_driver
     import libcloud.security
 except ImportError:
@@ -267,8 +267,10 @@ def get_nodes(client, module):
             matched_nodes = [node]
         else:
             nodes = client.list_nodes(location)
+
             matched_nodes = list(filter(lambda x: x.name == node,
                                         nodes))
+
         if len(matched_nodes) < 1:
             nodes_dict[node] = {'id': [], 'name': [], 'node': []}
         elif len(matched_nodes) >= 1:
@@ -573,6 +575,10 @@ def main():
 
     try:
         core(module)
+    except (InvalidCredsError), e:
+        module.fail_json(msg="Invalid Credentials Error: please check the "
+                         "Dimension Data Cloud credentials you provided then "
+                         "try again.")
     except (Exception), e:
         module.fail_json(msg=str(e))
 

--- a/ansible/dimensiondata/dimensiondata_load_balancer.py
+++ b/ansible/dimensiondata/dimensiondata_load_balancer.py
@@ -73,6 +73,11 @@ options:
           be taken to mean "Any Port"
     required: false
     default: None
+  listener_ip_address:
+    description:
+        - Must be a valid IPv4 in dot-decimal notation (x.x.x.x).
+    required: false
+    default: None
   protocol:
     description:
         - Choice of %s.
@@ -202,7 +207,8 @@ def main():
             algorithm=dict(default='ROUND_ROBIN', choices=lb_algs),
             members=dict(default=None, type='list'),
             ensure=dict(default='present', choices=['present', 'absent']),
-            verify_ssl_cert=dict(required=False, default=True, type='bool')
+            verify_ssl_cert=dict(required=False, default=True, type='bool'),
+            listener_ip_address=dict(required=False, default=None, type='str')
         )
     )
 
@@ -225,6 +231,7 @@ def main():
     members = module.params['members']
     verify_ssl_cert = module.params['verify_ssl_cert']
     ensure = module.params['ensure']
+    listener_ip_address = module.params['listener_ip_address']
 
     # -------------------
     # Instantiate drivers
@@ -257,10 +264,13 @@ def main():
                             for m in members]
             # Create load balancer
             try:
-                balancer = lb_driver.create_balancer(name, port, protocol,
-                                                     getattr(Algorithm,
-                                                             algorithm),
-                                                     members_list)
+                balancer = lb_driver.create_balancer(
+                    name,
+                    port,
+                    protocol,
+                    getattr(Algorithm, algorithm),
+                    members_list,
+                    ex_listener_ip_address=listener_ip_address)
                 module.exit_json(changed=True, msg="Success.",
                                  load_balancer=balancer_obj_to_dict(balancer))
             except DimensionDataAPIException as e:

--- a/ansible/module_utils/dimensiondata.py
+++ b/ansible/module_utils/dimensiondata.py
@@ -53,7 +53,7 @@ def get_credentials():
     # Environment failed try dot file
     if user_id is None or key is None:
         home = expanduser('~')
-        config = ConfigParser.SafeConfigParser()
+        config = ConfigParser.RawConfigParser()
         config.read("%s/.dimensiondata" % home)
         try:
             user_id = config.get("dimensiondatacloud", "DIDATA_USER")


### PR DESCRIPTION
## Commit sha 48e1e68:

Part of PR #34 

## Commit sha c1e28c0:

```
Use RawConfigParser instead of SafeConfigParser

This change keeps get_credentials() from returning false when
DIDATA_PASSWORD is a strong password that contains the '%' symbol.
Before this change, getting an entry with that symbol would cause
a ConfigParser.InterpolationSyntaxError which would cause the function
to return false. The Ansible user would then get a confusing "User
credentials not found" error. Since we don't expect the user to employ
any string interpolation in this file, we might as well do away with it.
```

## Commit sha 6a6d8e6:

```
Print out a more helpful message when invalid credentials are provided.

Before this change, Ansible would only print out '' as an error message
because libcloud's InvalidCredentialsError type did not have a message
attribute. This works around that problem by explicitly writing out a
more helpful message when the above exception is caught.
```